### PR TITLE
Possible Fix for Local URL bug

### DIFF
--- a/dsgnwrks-instagram-importer.php
+++ b/dsgnwrks-instagram-importer.php
@@ -248,6 +248,11 @@ function jts_instagram_img( $pics, $settings = array(), $tags='' ) {
 		$import['post_title'] = $insta_title;
 	}
 
+	$likes = '&hearts;&nbsp;' . count($pics->likes->data);
+	foreach ($pics->likes->data as $like) {
+		$likes = $likes .' <a href="http://instagram.com/'. $like->username .'">'. $like->username .'</a>';
+	}
+
 	$imgurl = $pics->images->standard_resolution->url;
 	$insta_url = esc_url( $pics->link );
 	$import['featured'] = isset( $settings['feat_image'] ) ? $settings['feat_image'] : true;
@@ -278,6 +283,7 @@ function jts_instagram_img( $pics, $settings = array(), $tags='' ) {
 		$content = str_replace( '**insta-link**', $insta_url, $content );
 		$content = str_replace( '**insta-location**', $loc, $content );
 		$content = str_replace( '**insta-filter**', $pics->filter, $content );
+		$content = str_replace( '**insta-likes**', $likes, $content );
 	}
 
 	$import['post_author'] = isset( $settings['author'] ) ? $settings['author'] : $user_ID;

--- a/settings.php
+++ b/settings.php
@@ -255,7 +255,7 @@ if ( !empty( $users ) && is_array( $users ) ) {
 
 								<tr valign="top">
 								<td colspan="2">
-									<p><strong>Post Content:</strong><br/>Add the imported Instagram data using these custom tags:<br/><code>**insta-text**</code>, <code>**insta-image**</code>, <code>**insta-image-link**</code>, <code>**insta-link**</code>, <code>**insta-location**</code>, <code>**insta-filter**</code></p>
+									<p><strong>Post Content:</strong><br/>Add the imported Instagram data using these custom tags:<br/><code>**insta-text**</code>, <code>**insta-image**</code>, <code>**insta-image-link**</code>, <code>**insta-link**</code>, <code>**insta-location**</code>, <code>**insta-filter**</code>, <code>**insta-likes**</code></p>
 									<?php
 									if ( isset( $opts[$id]['post_content'] ) ) {
 										$post_text = $opts[$id]['post_content'];


### PR DESCRIPTION
Justin,

Following up on our discussion on Twitter yesterday, I have a patch using wp_update_post that replaces the **link** fields with the locally cached URLs if the image is "featured". I've tested this on my WordPress install, but I don't know if my attempt at a minimal change breaks any other assumptions.

--Nick
