### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@
 language: php
 
 # Versions of PHP to test against
+# see https://wordpress.org/about/stats/ and https://wordpress.org/about/requirements/
 php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
     - hhvm
     - nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,25 @@ env:
     - WP_VERSION=latest WP_MULTISITE=1
     - WP_VERSION=4.0 WP_MULTISITE=0
     - WP_VERSION=4.0 WP_MULTISITE=1
-    - WP_VERSION=3.8 WP_MULTISITE=0
-    - WP_VERSION=3.8 WP_MULTISITE=1
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: WP_VERSION=3.8 WP_MULTISITE=0
-      php: nightly
-    - env: WP_VERSION=3.8 WP_MULTISITE=1
-      php: nightly
-   # PHP 5.3 is only available on precise (but hhvm is only on trusty)
+  exclude:
   include:
+    # WP 3.8 requires mysql_connect() which was removed in PHP 7
+    - php: 5.4
+      env: WP_VERSION=3.8 WP_MULTISITE=0
+    - php: 5.4
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    - php: 5.5
+      env: WP_VERSION=3.8 WP_MULTISITE=0
+    - php: 5.5
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    - php: 5.6
+      env: WP_VERSION=3.8 WP_MULTISITE=0
+    - php: 5.6
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    # PHP 5.3 is only available on precise (but hhvm is only on trusty)
     - dist: precise
       php: 5.3
       env: WP_VERSION=latest WP_MULTISITE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 
 # Versions of PHP to test against
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -30,7 +29,27 @@ matrix:
       php: nightly
     - env: WP_VERSION=3.8 WP_MULTISITE=1
       php: nightly
-
+   # PHP 5.3 is only available on precise (but hhvm is only on trusty)
+  include:
+    - dist: precise
+      php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - dist: precise
+      php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
+    - dist: precise
+      php: 5.3
+      env: WP_VERSION=4.0 WP_MULTISITE=0
+    - dist: precise
+      php: 5.3
+      env: WP_VERSION=4.0 WP_MULTISITE=1
+    - dist: precise
+      php: 5.3
+      env: WP_VERSION=3.8 WP_MULTISITE=0
+    - dist: precise
+      php: 5.3
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+        
 # Grab the setup script and execute
 before_script: # Make PHP 7 test work. https://github.com/WebDevStudios/CMB2/pull/885
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ env:
 
 matrix:
   fast_finish: true
-  exclude:
+  allow_failures:
+    - php: nightly
   include:
     # WP 3.8 requires mysql_connect() which was removed in PHP 7
     - php: 5.4


### PR DESCRIPTION
No rush on this. I thought you might appreciate it, though, and it'll certainly make me feel a little more confident about my PRs. 

This includes a few changes to test against current versions of PHP and avoid incompatibilities:

* Moved PHP 5.3 builds to Ubuntu Precise, because Travis CI doesn't support 5.3 on the default Trusty distro.
  - HHVM is only avaliable on Trusty, so just moving everything to Precise wasn't an option.
* Include PHP 7.0, 7.1, and 7.2
* Only test WP 3.8 on PHP < 7.0 
  - This is because WP 3.8 depends on `mysql_connect()`, which was removed in PHP 7.0
* Allow failures on PHP nightly
  - It's currently failing, but as far as I can tell, it's a bug in PHP, not your code.

With these changes, you now have a green build - see https://travis-ci.org/nfriedly/DsgnWrks-Instagram-Importer/builds/431689310

I structured things so that current-gen stuff is the "default" and legacy stuff is added to the matrix one-at-a-time. It's a little verbose, but it has a benefit of allowing you to add future versions of PHP and WordPress without having to remember to exclude the legacy stuff.

I'm targeting this PR at `future` but it should be easy enough to cherry-pick onto `master` if you'd like, especially if you squash-and-merge.